### PR TITLE
Allow PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ sudo: false
 matrix:
   fast_finish: true
   include:
+    - php: "7.2"
+    - php: "7.3"
     - php: "7.4"
     - php: "8.0"
     - php: "nightly"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "php": "^7.4|^8",
+    "php": ">=7.2.5",
     "paragonie/constant_time_encoding": "^2",
     "paragonie/sodium_compat": "^1.6"
   },

--- a/src/HiddenString.php
+++ b/src/HiddenString.php
@@ -24,21 +24,21 @@ final class HiddenString
     /**
      * @var string
      */
-    protected string $internalStringValue = '';
+    protected $internalStringValue = '';
 
     /**
      * Disallow the contents from being accessed via __toString()?
      *
      * @var bool
      */
-    protected bool $disallowInline = true;
+    protected $disallowInline = true;
 
     /**
      * Disallow the contents from being accessed via __sleep()?
      *
      * @var bool
      */
-    protected bool $disallowSerialization = true;
+    protected $disallowSerialization = true;
 
     /**
      * HiddenString constructor.

--- a/src/HiddenString.php
+++ b/src/HiddenString.php
@@ -141,6 +141,12 @@ final class HiddenString
         if (!$this->disallowInline) {
             return self::safeStrcpy($this->internalStringValue);
         }
+
+        if (\PHP_VERSION_ID < 70400) {
+            // Lower PHP versions is not allowed to throw exception
+            return '';
+        }
+
         throw new MisuseException(
             'This HiddenString object cannot be inlined as a string.'
         );

--- a/test/HiddenStringTest.php
+++ b/test/HiddenStringTest.php
@@ -58,11 +58,21 @@ final class HiddenStringTest extends TestCase
             $print = \print_r($hidden, true);
             $this->assertFalse(strpos($print, $str));
 
-            try {
-                $cast = (string) $hidden;
-                $this->assertNotFalse(strpos($cast, $str));
-            } catch (MisuseException $ex) {
-                $this->assertTrue($set[0]);
+            if (\PHP_VERSION_ID < 70400) {
+                // Lower PHP versions is not allowed to throw exception
+                $cast = (string)$hidden;
+                if ($set[0]) {
+                    $this->assertEquals('', $cast);
+                } else {
+                    $this->assertNotFalse(strpos($cast, $str));
+                }
+            } else {
+                try {
+                    $cast = (string)$hidden;
+                    $this->assertNotFalse(strpos($cast, $str));
+                } catch (MisuseException $ex) {
+                    $this->assertTrue($set[0]);
+                }
             }
 
             try {


### PR DESCRIPTION
If I just removed the typed properties, then we can be compatible for PHP 7.2. That would be excellent for interoperability. 

I dont see any drawbacks by doing this. But there might be something that was not documented in: https://github.com/paragonie/hidden-string/commit/9d9dd3d07b0a6d4dbefca81ef4d6e9009122cf52