### PR TITLE
Sodium_compat is not strictly needed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
   ],
   "require": {
     "php": "^7.4|^8",
-    "paragonie/constant_time_encoding": "^2",
-    "paragonie/sodium_compat": "^1.6"
+    "paragonie/constant_time_encoding": "^2"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
We do check if `sodium_memzero()` exists and if it doesn't we have a fallback. 

The fallback is currently "dead code". 

I decided to remove this package as it has zero side effects and (if you are not doing a super custom PHP installation) it is not needed. 